### PR TITLE
Use `core::error::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # hd-wallet crate changelog
 
 ## v0.6.0
-* Remove slip10-like derivation that can be instantiated with any curve: it is very inefficient
+* BREAKING: Remove slip10-like derivation that can be instantiated with any curve: it is very inefficient
   when instantiated with certain curves, and may also enable attacker to perform DoS attack by
   finding derivation path that results into very long computation [#14]
 * Add stark-specific derivation: secure and efficient derivation for stark curve [#14]
+* Use `Error` trait from `core` instead of `std` [#15]
+  * BREAKING: remove `std` feature as the lib is fully no_std now
 
 [#14]: https://github.com/LFDT-Lockness/hd-wallet/pull/14
+[#15]: https://github.com/LFDT-Lockness/hd-wallet/pull/15
 
 ## v0.5.1
 * Update docs and repo link [#11]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ generic-ec = { version = "0.4", default-features = false, features = ["curve-sta
 
 [features]
 default = []
-std = []
 # Adds support of secp256k1 curve to slip10 derivation
 curve-secp256k1 = ["generic-ec/curve-secp256k1", "slip10"]
 # Adds support of secp256r1 curve to slip10 derivation
@@ -37,7 +36,7 @@ curve-secp256r1 = ["generic-ec/curve-secp256r1", "slip10"]
 curve-ed25519 = ["generic-ec/curve-ed25519", "edwards"]
 # Enables Stark-specific derivation
 curve-stark = ["generic-ec/curve-stark", "stark"]
-all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-ed25519"]
+all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-ed25519", "curve-stark"]
 serde = ["dep:serde", "generic-ec/serde"]
 
 # Enables Slip10 derivation

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ let child_key = derive_using_generic_algo::<Secp256r1, Slip10>(master_key_pair);
 ```
 
 ### Features
-* `std`: enables std library support (mainly, it just implements `Error`
-  trait for the error types)
-* `curve-secp256k1`, `curve-secp256r1`, `curve-ed25519` add curve implementation into the crate
-  curves module
+* `curve-secp256k1`, `curve-secp256r1`, `curve-ed25519`, `curve-stark` add curve implementation
+   into the crate curves module
+* `all-curves` adds all curves listed above
+* `slip10`, `edwards`, `stark` add `slip10`, `edwards`, and `stark` HD derivations respectively
+* `serde` adds `serde::{Serialize, Deserialize}` traits implementation to the types in the library
 
 ## Join us in Discord!
 Feel free to reach out to us [in Discord](https://discordapp.com/channels/905194001349627914/1285268686147424388)!

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,8 +12,7 @@ impl fmt::Display for InvalidLength {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidLength {}
+impl core::error::Error for InvalidLength {}
 
 /// Value was out of range
 #[derive(Debug)]
@@ -25,8 +24,7 @@ impl fmt::Display for OutOfRange {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for OutOfRange {}
+impl core::error::Error for OutOfRange {}
 
 /// Error returned by parsing child index
 #[derive(Debug)]
@@ -46,9 +44,8 @@ impl fmt::Display for ParseChildIndexError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseChildIndexError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ParseChildIndexError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             ParseChildIndexError::ParseInt(e) => Some(e),
             ParseChildIndexError::IndexNotInRange(e) => Some(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,11 @@
 //! ```
 //!
 //! ### Features
-//! * `std`: enables std library support (mainly, it just implements [`Error`](std::error::Error)
-//!   trait for the error types)
-//! * `curve-secp256k1`, `curve-secp256r1`, `curve-ed25519` add curve implementation into the crate
-//!   [curves] module
+//! * `curve-secp256k1`, `curve-secp256r1`, `curve-ed25519`, `curve-stark` add curve implementation
+//!    into the crate [curves] module
+//! * `all-curves` adds all curves listed above
+//! * `slip10`, `edwards`, `stark` add [`slip10`], [`edwards`], and [`stark`] HD derivations respectively
+//! * `serde` adds `serde::{Serialize, Deserialize}` traits implementation to the types in the library
 //!
 //! ## Join us in Discord!
 //! Feel free to reach out to us [in Discord](https://discordapp.com/channels/905194001349627914/1285268686147424388)!
@@ -65,7 +66,7 @@
 //! [slip10-spec]: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
 //! [bip32-spec]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![forbid(missing_docs, unsafe_code)]
 #![cfg_attr(not(test), forbid(unused_crate_dependencies))]
 


### PR DESCRIPTION
PR changes the lib to use `Error` trait from `core` instead of `std`. It also removes `std` feature as it's not needed anymore.