### PR TITLE
Fix push trigger branch in OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '27 4 * * 2'
   push:
-    branches: [ "cggmp24/m" ]
+    branches: [ "m" ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Fixes the `push` trigger to listen on the actual default branch (`m`) instead of `cggmp24/m` (which was copy-pasted from `cggmp21` by mistake).